### PR TITLE
misprint: glog/warning

### DIFF
--- a/src/figwheel/repl.cljc
+++ b/src/figwheel/repl.cljc
@@ -604,7 +604,7 @@
     (do
       (.setLevel logger' lvl)
       (debug (str "setting log level to " level)))
-    (glog/warn (str "Log level " (pr-str level) " doesn't exist must be one of "
+    (glog/warning (str "Log level " (pr-str level) " doesn't exist must be one of "
                     (pr-str '("severe" "warning" "info" "config" "fine" "finer" "finest"))))))
 
 (defn init-log-level! []


### PR DESCRIPTION
I've tried to suppress messages from websockets with this function and gave it a keyword instead of a string, in turn it gave me an exception instead of a warning. :-)