### PR TITLE
Using glog/warning instead of glog/warn

### DIFF
--- a/src/figwheel/repl.cljc
+++ b/src/figwheel/repl.cljc
@@ -607,7 +607,7 @@
     (do
       (.setLevel logger' lvl)
       (debug (str "setting log level to " level)))
-    (glog/warn (str "Log level " (pr-str level) " doesn't exist must be one of "
+    (glog/warning (str "Log level " (pr-str level) " doesn't exist must be one of "
                     (pr-str '("severe" "warning" "info" "config" "fine" "finer" "finest"))))))
 
 (defn init-log-level! []


### PR DESCRIPTION
This PR fixes a bug and compiler warning about the non existing `goog.log/warn` API.

The correct API to use is [`goog.log/warning`](https://google.github.io/closure-library/api/goog.log.html).

Here's the log output again for reference:

```
[Figwheel:WARNING] Compile Warning   target/public/cljs-out/common/figwheel/repl.cljc   line:610  column:6

  Use of undeclared Var goog.log/warn

  605  (defn set-log-level [logger' level]
  606    (if-let [lvl (get log-levels level)]
  607      (do
  608        (.setLevel logger' lvl)
  609        (debug (str "setting log level to " level)))
  610      (glog/warn (str "Log level " (pr-str level) " doesn't exist must be one of "
            ^---
  611                      (pr-str '("severe" "warning" "info" "config" "fine" "finer" "finest"))))))
  612
  613  (defn init-log-level! []
  614    (doseq [logger' (cond-> [logger]
  615                      (exists? js/figwheel.core)
```

More details of this change have been discussed in #10 already.

Fixes #10