### PR TITLE
Fix breaking Google Closure breaking change and ns spec error

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,6 @@
         ring-cors/ring-cors {:mvn/version "0.1.13"}}
  :aliases
  {:dev {:extra-deps
-        {ring {:mvn/version "1.9.1"}
+        {ring/ring {:mvn/version "1.9.1"}
          org.eclipse.jetty.websocket/websocket-servlet {:mvn/version "9.4.36.v20210114"}
-         org.eclipse.jetty.websocket/websocket-server {:mvn/version "9.4.36.v20210114"}
-         }}}}
+         org.eclipse.jetty.websocket/websocket-server {:mvn/version "9.4.36.v20210114"}}}}}

--- a/src/figwheel/repl/logging.cljs
+++ b/src/figwheel/repl/logging.cljs
@@ -2,8 +2,8 @@
   (:require [goog.log :as glog]
             [goog.object :as gobj]
             [clojure.string :as string])
-  (:import [goog.debug.Console]
-           [goog.debug.Logger]))
+  (:import [goog.debug Console]
+           [goog.log Logger]))
 
 (defn get-logger [nm]
   (.call glog/getLogger nil nm))
@@ -22,7 +22,7 @@
 
 (defonce LogLevel
   (or goog.log.Level
-      goog.debug.Logger.Level))
+      goog.log.Logger.Level))
 
 (defn debug [log msg]
   (.call glog/log nil log LogLevel.FINEST msg))


### PR DESCRIPTION
This builds on the following pull request but also fixes the breaking change in Google Closure moving `Logger` to a new namespace.

No need to merge the following pull request if this one is accepted.

https://github.com/bhauman/figwheel-repl/pull/17

Tested with ClojureScript 1.11.4